### PR TITLE
Fix bug in entering cone coordinates

### DIFF
--- a/R/ablandscape_fit.R
+++ b/R/ablandscape_fit.R
@@ -170,7 +170,7 @@ fit_cone_pars <- function(fit) {
     if (fit$control$optimise.cone.slope) {
       cone_slope <- result$par[1]
       if (fit$control$optimise.cone.coords) {
-        cone_coords <- matrix(result$par[-1], nrow(fit$logtiters), 2)
+        cone_coords <- matrix(result$par[-1], nrow(fit$logtiters), 2, byrow = T)
       } else {
         cone_coords <- fit$control$start.cone.coords
       }


### PR DESCRIPTION
My average landscape when fitting with the "cone" method was wrong (light surfaces are individual serum fits, dark surface is the supposed average landscape):
<img width="760" alt="Screenshot 2023-09-28 at 14 33 49" src="https://github.com/acorg/ablandscapes/assets/44381390/882065a2-345f-438e-8113-33f31ce6a875">

Comparing the cone coordinates when (1) sera are fit all together to (2) sera are fit individually, with their individual slopes fixed to the slope from (1), it is clear that the cone coordinates are simply being entered into the matrix incorrectly:

(1) Fit together:
<img width="200" alt="Screenshot 2023-09-28 at 14 39 36" src="https://github.com/acorg/ablandscapes/assets/44381390/4bf78e65-938b-42ea-90c7-da7bc84ced7b">

(2) Individual fits:
<img width="193" alt="Screenshot 2023-09-28 at 14 37 57" src="https://github.com/acorg/ablandscapes/assets/44381390/6272e45a-576c-46b8-8125-aad0c1f6a8ba">

Fixing this with the commit above then results in correct the coordinates and average landscape:


<img width="197" alt="Screenshot 2023-09-28 at 14 41 40" src="https://github.com/acorg/ablandscapes/assets/44381390/f6fc46cd-8e1f-4206-a1b4-1861ab8843ff">

<br>

<img width="770" alt="Screenshot 2023-09-28 at 14 43 03" src="https://github.com/acorg/ablandscapes/assets/44381390/29ef31e5-d57d-4740-92a6-b040947ba39b">
