### PR TITLE
Fix bug in calculating residuals

### DIFF
--- a/R/ablandscape_fit.R
+++ b/R/ablandscape_fit.R
@@ -99,7 +99,7 @@ ablandscape.fit <- function(
   )
   
   # Get residuals
-  fit_residuals <- fit$logtiters - fit$fitted.values
+  fit_residuals <- t(t(fit$logtiters) - fit$fitted.values)
   
   fit$residuals <- fit_residuals
   fit$residuals[fit$morethans | fit$lessthans] <- NA


### PR DESCRIPTION
Fitted values were subtracted by column rather than by row when calculating residuals:

titers:
<img width="188" alt="Screenshot 2023-10-06 at 11 39 10" src="https://github.com/acorg/ablandscapes/assets/44381390/cfd05e1d-8884-45c9-9874-bcec08ab6b54">

= logtiters:
<img width="214" alt="Screenshot 2023-10-06 at 11 39 21" src="https://github.com/acorg/ablandscapes/assets/44381390/fc6a42b8-704e-4dcd-852a-84a63b2ce596">

with fitted values:
<img width="590" alt="Screenshot 2023-10-06 at 11 39 25" src="https://github.com/acorg/ablandscapes/assets/44381390/3996f1ea-12be-4a15-afe6-40cebd28c093">

Used to give residuals:
<img width="319" alt="Screenshot 2023-10-06 at 11 39 52" src="https://github.com/acorg/ablandscapes/assets/44381390/e2d01a41-fcd2-40c6-968d-86ce0ed1f922">

(see that the fitted values for WT, BA.1, BA.2 are being subtracted down the WT column, rather than across the different antigens, with the same value being subtracted down each column)

After fix, residuals are now:
<img width="285" alt="Screenshot 2023-10-06 at 11 39 36" src="https://github.com/acorg/ablandscapes/assets/44381390/570525fa-9c55-4950-a659-e2c0a1de3c26">

Separately, it would be nice to have residuals calculated taking into account the different cone heights, which would represent the error due to landscapes not being a good model of the titers, discounting reactivity differences. Maybe I'll implement at some point...
